### PR TITLE
Hidden import view

### DIFF
--- a/mc2/controllers/docker/hidden_import.py
+++ b/mc2/controllers/docker/hidden_import.py
@@ -17,7 +17,7 @@ from mc2.controllers.docker.models import DockerController
 
 
 class HiddenImportForm(forms.Form):
-    name = forms.CharField()
+    name = forms.CharField(required=False)
     app_data = forms.CharField(widget=forms.Textarea)
 
 
@@ -32,6 +32,6 @@ class HiddenImportView(ControllerViewMixin):
         DockerController.from_marathon_app_data(
             self.request.user, json.loads(form.cleaned_data['app_data']),
             form.cleaned_data['name'])
-        messages.info(self.request, "App created: {name}".format(
+        messages.info(self.request, u"App created: {name}".format(
             **form.cleaned_data))
         return HttpResponseRedirect('/')

--- a/mc2/controllers/docker/hidden_import.py
+++ b/mc2/controllers/docker/hidden_import.py
@@ -1,0 +1,37 @@
+"""
+This module contains a very primitive view for importing Marathon app
+definitions. There's very little validation or feedback, so it should only be
+used by people who know what they're doing and have access to server logs to
+see the inevitable stack traces.
+"""
+
+import json
+
+from django import forms
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+
+from mc2.controllers.base.views import ControllerViewMixin
+from mc2.controllers.docker.models import DockerController
+
+
+class HiddenImportForm(forms.Form):
+    name = forms.CharField()
+    app_data = forms.CharField(widget=forms.Textarea)
+
+
+class HiddenImportView(ControllerViewMixin):
+    def get(self, request):
+        form = HiddenImportForm()
+        return render(request, 'hidden_import.html', {'form': form})
+
+    def post(self, request):
+        form = HiddenImportForm(request.POST)
+        assert form.is_valid()
+        DockerController.from_marathon_app_data(
+            self.request.user, json.loads(form.cleaned_data['app_data']),
+            form.cleaned_data['name'])
+        messages.info(self.request, "App created: {name}".format(
+            **form.cleaned_data))
+        return HttpResponseRedirect('/')

--- a/mc2/controllers/docker/models.py
+++ b/mc2/controllers/docker/models.py
@@ -99,13 +99,13 @@ class DockerController(Controller):
             "slug": app_data.pop("id"),
             "marathon_cpus": app_data.pop("cpus"),
             "marathon_mem": app_data.pop("mem"),
-            "marathon_instances": app_data.pop("instances"),
+            "marathon_instances": app_data.pop("instances", 1),
             "marathon_cmd": app_data.pop("cmd", ""),
             "docker_image": docker_dict.pop("image"),
         }
         # TODO: Better error:
         assert docker_dict.pop("network") == "BRIDGE"
-        assert docker_dict.pop("forcePullImage") is True
+        assert docker_dict.pop("forcePullImage", True) is True
         assert app_data.pop("container") == {"type": "DOCKER"}
 
         if "portMappings" in docker_dict:
@@ -133,7 +133,7 @@ class DockerController(Controller):
         if "healthChecks" in app_data:
             # TODO: Validate the rest of the health check data.
             # TODO: Better errors:
-            assert app_data.pop("ports") == [0]
+            assert app_data.pop("ports", [0]) == [0]
             hc = app_data.pop("healthChecks")
             assert len(hc) == 1
             args["marathon_health_check_path"] = hc[0]["path"]

--- a/mc2/controllers/docker/templates/hidden_import.html
+++ b/mc2/controllers/docker/templates/hidden_import.html
@@ -1,0 +1,49 @@
+{% extends "skins/base.html" %}
+{% load i18n admin_urls admin_static %}
+
+{% block navbar %}
+<ul class="nav" id="main-menu-left">
+  <li><a href="{% url 'home' %}">Home</a></li>
+  <li class="active"><a href="#">New</a></li>
+</ul>
+{% endblock %}
+
+{% block script %}
+<script type="text/javascript">
+  $(function() {
+    $(".inline.env").formset({
+      prefix: "env",
+      addCssClass: "add-row btn btn-primary",
+      deleteCssClass: "delete-row btn btn-danger btn-xs",
+    })
+  })
+    $(function() {
+      $(".inline.label").formset({
+        prefix: "label",
+        addCssClass: "add-row btn btn-primary",
+        deleteCssClass: "delete-row btn btn-danger btn-xs",
+      })
+    })
+
+</script>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-6">
+    <!-- general form elements -->
+    <div class="box box-primary">
+      <div class="box-header with-border">
+        <h3 class="box-title">Import marathon app JSON</h3>
+      </div>
+
+      <form role="form" method="POST">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <p><input type="submit" value="Submit" class="btn btn-primary"/></p>
+      </form>
+
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/mc2/controllers/docker/tests/test_docker_controller.py
+++ b/mc2/controllers/docker/tests/test_docker_controller.py
@@ -4,6 +4,8 @@ import pytest
 import responses
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test.client import Client
 from hypothesis import given, settings as hsettings
 from hypothesis.extra.django import TestCase
 from hypothesis.strategies import text, random_module, lists, just
@@ -46,7 +48,7 @@ def docker_controller(with_envvars=True, with_labels=True, **kw):
     # TODO: Figure out why the field validation isn't being applied.
     kw.setdefault("slug", text().map(
         lambda t: "".join(t.replace(":", "").split())))
-    kw.setdefault("owner", models(User))
+    kw.setdefault("owner", models(User, is_active=just(True)))
     # The model generator sees `controller_ptr` (from the PolymorphicModel
     # magic) as a mandatory field and objects if we don't provide a value for
     # it.
@@ -205,6 +207,35 @@ class DockerControllerHypothesisTestCase(TestCase):
         app_data = controller.get_marathon_app_data()
         new_controller = DockerController.from_marathon_app_data(
             controller.owner, app_data, name=name)
+        assert new_controller.name == name
+
+        app_data_with_name = json.loads(json.dumps(app_data))
+        app_data_with_name["labels"]["name"] = name
+        assert app_data_with_name == new_controller.get_marathon_app_data()
+
+    @hsettings(perform_health_check=False, max_examples=50)
+    @given(_r=random_module(), controller=docker_controller(), name=text())
+    def test_hidden_import_view(self, _r, controller, name):
+        """
+        A model imported through the hidden view generates the same app_data
+        as the model it was imported from, but with the name field overridden.
+
+        We limit the number of examples we generate because we don't need
+        hundreds of examples to verify that this behaviour is correct.
+        """
+        app_data = controller.get_marathon_app_data()
+        user = controller.owner
+        user.set_password("password")  # So we can log in.
+        user.save()
+        client = Client()
+        assert client.login(username=user.username, password="password")
+        resp = client.post(
+            reverse('controllers.docker:hidden_import'),
+            {"name": name, "app_data": json.dumps(app_data)})
+        assert resp.status_code == 302
+
+        new_controller = DockerController.objects.exclude(
+            pk=controller.pk).get()
         assert new_controller.name == name
 
         app_data_with_name = json.loads(json.dumps(app_data))

--- a/mc2/controllers/docker/urls.py
+++ b/mc2/controllers/docker/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-from mc2.controllers.docker import views
+from mc2.controllers.docker import views, hidden_import
 
 
 urlpatterns = patterns(
@@ -14,4 +14,8 @@ urlpatterns = patterns(
         r'^(?P<controller_pk>\d+)/$',
         views.DockerControllerEditView.as_view(),
         name='edit'),
+    url(
+        r'^hidden_import/$',
+        hidden_import.HiddenImportView.as_view(),
+        name='hidden_import'),
 )


### PR DESCRIPTION
Importing arbitrary Marathon app definition data is a hard problem, fraught with terrors that mortals cannot fathom. Therefore, the intention of this work is to implement a minimal (and very hacky) import view that is only reachable by visiting the appropriate URL (not linked from the rest of the UI). There will be minimal validation (aside from that in the importer itself, see #44) and there may be weirdnesses in the imported model that need to be fixed by hand. If an import fails, looking at the server logs is the expected debugging avenue.