### PR TITLE
Use WhiteNoise to serve static files

### DIFF
--- a/mc2/wsgi.py
+++ b/mc2/wsgi.py
@@ -16,6 +16,8 @@ framework.
 import os
 from django.core.wsgi import get_wsgi_application
 
+from whitenoise.django import DjangoWhiteNoise
+
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
 # if running multiple sites in the same mod_wsgi process. To fix this, use
 # mod_wsgi daemon mode with each site in its own daemon process, or use
@@ -30,3 +32,4 @@ application = get_wsgi_application()
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
+application = DjangoWhiteNoise(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ python-social-auth
 raven==5.0.0
 redis
 unicore.hub.client>=0.2.0
+whitenoise<2.1.0,>=2.0.0


### PR DESCRIPTION
Reduce dependence on having nginx set up a certain way and simplify containerization.