### PR TITLE
Fix starting of apps in app importer

### DIFF
--- a/mc2/controllers/docker/hidden_import.py
+++ b/mc2/controllers/docker/hidden_import.py
@@ -12,6 +12,7 @@ from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
+from mc2 import tasks
 from mc2.controllers.base.views import ControllerViewMixin
 from mc2.controllers.docker.models import DockerController
 from mc2.organizations.utils import active_organization
@@ -30,10 +31,11 @@ class HiddenImportView(ControllerViewMixin):
     def post(self, request):
         form = HiddenImportForm(request.POST)
         assert form.is_valid()
-        DockerController.from_marathon_app_data(
+        controller = DockerController.from_marathon_app_data(
             self.request.user, active_organization(self.request),
             json.loads(form.cleaned_data['app_data']),
             form.cleaned_data['name'])
+        tasks.start_new_controller.delay(controller.pk)
         messages.info(self.request, u"App created: {name}".format(
             **form.cleaned_data))
         return HttpResponseRedirect('/')

--- a/mc2/controllers/docker/tests/test_docker_controller.py
+++ b/mc2/controllers/docker/tests/test_docker_controller.py
@@ -230,9 +230,13 @@ class DockerControllerHypothesisTestCase(TestCase):
         user.save()
         client = Client()
         assert client.login(username=user.username, password="password")
-        resp = client.post(
-            reverse('controllers.docker:hidden_import'),
-            {"name": name, "app_data": json.dumps(app_data)})
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST, '%s/v2/apps' % settings.MESOS_MARATHON_HOST,
+                body="{}", content_type="application/json", status=201)
+            resp = client.post(
+                reverse('controllers.docker:hidden_import'),
+                {"name": name, "app_data": json.dumps(app_data)})
         assert resp.status_code == 302
 
         new_controller = DockerController.objects.exclude(

--- a/mc2/controllers/docker/tests/test_docker_controller.py
+++ b/mc2/controllers/docker/tests/test_docker_controller.py
@@ -231,6 +231,8 @@ class DockerControllerHypothesisTestCase(TestCase):
         client = Client()
         assert client.login(username=user.username, password="password")
         with responses.RequestsMock() as rsps:
+            # If the Marathon request hasn't occurred by the time this context
+            # is closed then the test will fail.
             rsps.add(
                 responses.POST, '%s/v2/apps' % settings.MESOS_MARATHON_HOST,
                 body="{}", content_type="application/json", status=201)


### PR DESCRIPTION
Need to add something like `tasks.start_new_controller.delay(controller.pk)` to the app importer view so that the app is properly created and started.