### PR TITLE
Smaller docker image

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -12,7 +12,7 @@ if not User.objects.filter(username='admin').count():
 " | django-admin.py shell
 
 echo "=> Starting nginx"
-nginx; service nginx reload
+nginx
 
 echo "=> Starting Supervisord"
 supervisord -c /etc/supervisord.conf

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        off;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
The current docker image is about 750MB, which is a huge problem when bootstrapping a new seed cluster. We should use an Alpine base image instead of a Debian one to cut out a bunch of unnecessary stuff.