### PR TITLE
Hypothesis: also limit generated app names

### DIFF
--- a/mc2/controllers/docker/tests/test_docker_controller.py
+++ b/mc2/controllers/docker/tests/test_docker_controller.py
@@ -46,7 +46,8 @@ def docker_controller(with_envvars=True, with_labels=True, **kw):
     # so we remove them from the generated value.
     # TODO: Build a proper SlugField strategy.
     # TODO: Figure out why the field validation isn't being applied.
-    slug = text().map(lambda t: "".join(t.replace(":", "").split()))
+    # Slugs must be domain-name friendly - used in the "generic" domain
+    slug = text(string.ascii_letters + string.digits + '-')
     kw.setdefault("slug", slug)
 
     kw.setdefault("owner", models(User, is_active=just(True)))


### PR DESCRIPTION
Since they are used in generated domain names, we can't just allow any value.