### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,7 @@ COPY docker/mc2.supervisor.conf /etc/supervisor/conf.d/
 RUN pip install gunicorn supervisor "Django<1.9,>=1.8" \
     && pip install -e .
 
-RUN mkdir -p /etc/supervisor/conf.d/
 RUN mkdir -p /var/log/supervisor
-
-RUN chmod +x /deploy/docker-entrypoint.sh
 
 EXPOSE 80
 CMD ["/deploy/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM praekeltfoundation/python-base:alpine
 
+# Install runtime dependencies for MC2 as well as Nginx and Redis
 RUN apk --no-cache add nginx redis libffi postgresql-dev
 
-ENV PROJECT_ROOT /deploy/
-ENV DJANGO_SETTINGS_MODULE mc2.settings
-ENV MESOS_MARATHON_HOST http://servicehost:8080
-
-WORKDIR /deploy/
-
+# Copy in bits of MC2 source we need
 COPY mc2 /deploy/mc2
 COPY manage.py \
     requirements.txt \
@@ -18,13 +14,22 @@ COPY manage.py \
     docker/docker-entrypoint.sh \
         /deploy/
 
+ENV PROJECT_ROOT /deploy/
+WORKDIR /deploy/
+
+# Install MC2 as well as gunicorn and supervisor
+RUN pip install gunicorn supervisor "Django<1.9,>=1.8" \
+    && pip install -e .
+
+# Set some basic config
+ENV DJANGO_SETTINGS_MODULE mc2.settings
+ENV MESOS_MARATHON_HOST http://servicehost:8080
+
+# Copy in Nginx and Supervisor config
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/mc2.nginx.conf /etc/nginx/conf.d/
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/mc2.supervisor.conf /etc/supervisor/conf.d/
-
-RUN pip install gunicorn supervisor "Django<1.9,>=1.8" \
-    && pip install -e .
 
 RUN mkdir -p /var/log/supervisor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM praekeltfoundation/python-base:alpine
 
 # Install runtime dependencies for MC2 as well as Nginx and Redis
-RUN apk --no-cache add nginx redis libffi postgresql-dev
+RUN apk --no-cache add libffi libpq \
+    nginx redis
 
 # Copy in bits of MC2 source we need
 COPY mc2 /deploy/mc2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:2.7.11-alpine
+FROM praekeltfoundation/python-base:alpine
 
-RUN apk --no-cache add nginx redis libffi postgresql ca-certificates
+RUN apk --no-cache add nginx redis libffi postgresql-dev
 
 ENV PROJECT_ROOT /deploy/
 ENV DJANGO_SETTINGS_MODULE mc2.settings
@@ -21,11 +21,8 @@ ADD docker/mc2.nginx.conf /etc/nginx/conf.d/
 ADD docker/supervisord.conf /etc/
 ADD docker/mc2.supervisor.conf /etc/supervisor/conf.d/
 
-RUN apk --no-cache add --virtual devdeps gcc musl-dev python-dev libffi-dev postgresql-dev \
-    && pip install gunicorn supervisor "Django<1.9,>=1.8" \
-    && pip install -e . \
-    && rm -rf ~/.cache/pip \
-    && apk del devdeps
+RUN pip install gunicorn supervisor "Django<1.9,>=1.8" \
+    && pip install -e .
 
 RUN mkdir -p /etc/supervisor/conf.d/
 RUN mkdir -p /var/log/supervisor
@@ -33,4 +30,4 @@ RUN mkdir -p /var/log/supervisor
 RUN chmod +x /deploy/docker-entrypoint.sh
 
 EXPOSE 80
-ENTRYPOINT ["/deploy/docker-entrypoint.sh"]
+CMD ["/deploy/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,19 @@ ENV MESOS_MARATHON_HOST http://servicehost:8080
 WORKDIR /deploy/
 
 COPY mc2 /deploy/mc2
-ADD manage.py /deploy/
-ADD requirements.txt /deploy/
-ADD requirements-dev.txt /deploy/
-ADD setup.py /deploy/
-ADD README.rst /deploy/
-ADD VERSION /deploy/
-ADD docker/docker-entrypoint.sh /deploy/
-ADD docker/nginx.conf /etc/nginx/nginx.conf
-ADD docker/mc2.nginx.conf /etc/nginx/conf.d/
-ADD docker/supervisord.conf /etc/
-ADD docker/mc2.supervisor.conf /etc/supervisor/conf.d/
+COPY manage.py \
+    requirements.txt \
+    requirements-dev.txt \
+    setup.py \
+    README.rst \
+    VERSION \
+    docker/docker-entrypoint.sh \
+        /deploy/
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/mc2.nginx.conf /etc/nginx/conf.d/
+COPY docker/supervisord.conf /etc/supervisord.conf
+COPY docker/mc2.supervisor.conf /etc/supervisor/conf.d/
 
 RUN pip install gunicorn supervisor "Django<1.9,>=1.8" \
     && pip install -e .


### PR DESCRIPTION
This Docker image is functionally identical to the old one - same supervisor + Nginx + Redis + MC2 setup. But there are some changes:
* Use new `praekeltfoundation/python-base:alpine` base image with prebuilt Python packages
* Reduce the number of `COPY`/`ADD` commands
* Remove unneeded `RUN` commands
* `CMD` instead of `ENTRYPOINT` - `dumb-init` now manages processes
* Reorder for better layer caching and add comments

Advantages:
* Faster build times - no need to install dev dependencies
* ~10MB reduction in uncompressed image size
* 9 fewer layers for faster pulls (23 -> 14)