### PR TITLE
Run everything under supervisor and collect logs to stdout/stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ COPY docker/mc2.nginx.conf /etc/nginx/conf.d/
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/mc2.supervisor.conf /etc/supervisor/conf.d/
 
+# Send Nginx access and error logs to stdout/stderr
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
 RUN mkdir -p /var/log/supervisor
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,6 @@ COPY docker/mc2.nginx.conf /etc/nginx/conf.d/
 COPY docker/supervisord.conf /etc/supervisor/supervisord.conf
 COPY docker/mc2.supervisor.conf /etc/supervisor/conf.d/
 
-# Send Nginx access and error logs to stdout/stderr
-RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log
-
 RUN mkdir -p /var/log/supervisor
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV MESOS_MARATHON_HOST http://servicehost:8080
 # Copy in Nginx and Supervisor config
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/mc2.nginx.conf /etc/nginx/conf.d/
-COPY docker/supervisord.conf /etc/supervisord.conf
+COPY docker/supervisord.conf /etc/supervisor/supervisord.conf
 COPY docker/mc2.supervisor.conf /etc/supervisor/conf.d/
 
 # Send Nginx access and error logs to stdout/stderr

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,6 +16,3 @@ nginx
 
 echo "=> Starting Supervisord"
 supervisord -c /etc/supervisord.conf
-
-echo "=> Tailing logs"
-tail -qF /var/log/supervisor/*.log

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -12,4 +12,4 @@ if not User.objects.filter(username='admin').count():
 " | django-admin.py shell
 
 echo "=> Starting Supervisord"
-supervisord -c /etc/supervisord.conf
+supervisord -c /etc/supervisor/supervisord.conf

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -11,8 +11,5 @@ if not User.objects.filter(username='admin').count():
     User.objects.create_superuser('admin', 'admin@example.com', 'pass')
 " | django-admin.py shell
 
-echo "=> Starting nginx"
-nginx
-
 echo "=> Starting Supervisord"
 supervisord -c /etc/supervisord.conf

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "setting up the database"
-django-admin.py migrate
+django-admin.py migrate --noinput
 django-admin.py collectstatic --noinput
 
 echo "from django.contrib.auth.models import User

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -12,4 +12,4 @@ if not User.objects.filter(username='admin').count():
 " | django-admin.py shell
 
 echo "=> Starting Supervisord"
-supervisord -c /etc/supervisor/supervisord.conf
+exec supervisord -c /etc/supervisor/supervisord.conf

--- a/docker/mc2.supervisor.conf
+++ b/docker/mc2.supervisor.conf
@@ -1,16 +1,25 @@
 [program:redis]
 command = redis-server
 directory = /
-redirect_stderr = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:mc2]
 command = gunicorn --bind 0.0.0.0:8000 mc2.wsgi
 environment = DJANGO_SETTINGS_MODULE="mc2.settings"
 directory = /deploy/
-redirect_stderr = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:celery]
 command = celery worker -A mc2 -l INFO
 environment = DJANGO_SETTINGS_MODULE="mc2.settings"
 directory = /deploy/
-redirect_stderr = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docker/mc2.supervisor.conf
+++ b/docker/mc2.supervisor.conf
@@ -1,3 +1,10 @@
+[program:nginx]
+command = nginx -g "daemon off;"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 [program:redis]
 command = redis-server
 directory = /

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,7 +20,7 @@ http {
 
     access_log  /var/log/nginx/access.log  main;
 
-    sendfile        off;
+    sendfile        on;
     #tcp_nopush     on;
 
     keepalive_timeout  65;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,7 +1,7 @@
 user  nginx;
 worker_processes  1;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  /dev/stderr warn;
 pid        /var/run/nginx.pid;
 
 
@@ -18,7 +18,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /dev/stdout  main;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,19 +1,30 @@
-; supervisor config file
+# supervisor config file
+# Adapted from the config file distributed with the supervisor package on Debian
+# Jessie
 
-[unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
-chmod=0700                      ; sockef file mode (default 0700)
-
+# Enable supervisord in non-daemon mode. Disable the logfile as we receive
+# log messages via stdout/err. Set up the child process log directory in case
+# the user doesn't set logging to stdout/err.
 [supervisord]
-logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+nodaemon = true
+logfile = NONE
+pidfile = /var/run/supervisord.pid
+childlogdir = /var/log/supervisor
+
+
+# Enable supervisorctl via RPC interface over Unix socket
+[unix_http_server]
+file = /var/run/supervisor.sock
+chmod = 0700
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl = unix:///var/run/supervisor.sock
 
+
+# Include conf files for child processes
+# Debian/Ubuntu packages use /etc/supervisor/conf.d
 [include]
 files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
Docker containers like this are kind of a mess... but let's at least try to do it right.
* Use the supervisor config from [`praekeltfoundation/docker-supervisor`](https://github.com/praekeltfoundation/docker-supervisor) - runs supervisor in `nodaemon` mode.
* Send supervisor child program logs straight to stdout/stderr
* Start Nginx with supervisor in non-daemon mode, send all logs to stdout/stderr
* Move supervisor config to standard Debian paths
* `exec` the supervisor process so the shell goes away and we can send signals to the process

Advantages:
* Fewer running processes
* Actually collect logs from everything
* Signals to the process work (`^C` or `docker stop <container>` should now work)